### PR TITLE
Update supermarket-omnibus-cookbook to use chef-ingredient

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,3 @@
 source "https://supermarket.chef.io"
 
 metadata
-
-cookbook 'chef-server-ingredient', '~> 0.4.0'
-#cookbook 'chef-server-ingredient', git: 'https://github.com/chef-cookbooks/chef-server-ingredient.git'

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ default['supermarket_omnibus']['chef_oauth2_secret'] = 'a49402219627cfa6318d58b1
 default['supermarket_omnibus']['chef_oauth2_verify_ssl'] = false
 ```
 
-If you wish to consume nightly releases of specify a package source, you can do that now:
+If you wish to specify a package version, a repository or a source, you can do that now:
 ```ruby
-default['supermarket_package']['packagecloud_repo'] = 'chef/stable'
+default['supermarket_omnibus']['package_version'] = '1.2.3'
 
-# use the following to consume nightly builds of packagecloud:
-default['supermarket_package']['packagecloud_repo'] = 'chef/current'
+# install from the repository of nightly packages
+default['supermarket_omnibus']['package_repo'] = 'chef-current'
 
 # OR, specify a Supermarket package explicitly from a location of your choosing
-default['supermarket_package']['package_source'] = 'http://bit.ly/98K8eH'
+default['supermarket_omnibus']['package_url'] = 'http://bit.ly/98K8eH'
 ```
 
 # License and Authors

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,7 +5,7 @@ default['supermarket_omnibus']['chef_oauth2_secret'] = nil
 default['supermarket_omnibus']['chef_oauth2_verify_ssl'] = false
 
 default['supermarket_omnibus']['package_url'] = nil
-default['supermarket_omnibus']['package_version'] = nil
+default['supermarket_omnibus']['package_version'] = :latest
 default['supermarket_omnibus']['package_repo'] = 'chef-stable'
 # use the following to consume nightly builds of packagecloud:
 #default['supermarket_omnibus']['package_repo'] = 'chef-current'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,8 +4,8 @@ default['supermarket_omnibus']['chef_oauth2_app_id'] = nil
 default['supermarket_omnibus']['chef_oauth2_secret'] = nil
 default['supermarket_omnibus']['chef_oauth2_verify_ssl'] = false
 
-default['supermarket_package']['packagecloud_repo'] = 'chef/stable'
+default['supermarket_omnibus']['package_url'] = nil
+default['supermarket_omnibus']['package_version'] = nil
+default['supermarket_omnibus']['package_repo'] = 'chef-stable'
 # use the following to consume nightly builds of packagecloud:
-#default['supermarket_package']['packagecloud_repo'] = 'chef/current'
-# OR, specify a Supermarket package explicitly
-#default['supermarket_package']['package_source'] = 'https://web-dl.packagecloud.io/chef/stable/packages/el/6/supermarket-1.9.0~alpha.0-1.el5.x86_64.rpm'
+#default['supermarket_omnibus']['package_repo'] = 'chef-current'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,5 +8,5 @@ issues_url       'https://github.com/irvingpop/supermarket-omnibus-cookbook/issu
 version          '0.4.0'
 
 
-depends 'chef-server-ingredient'
+depends 'chef-ingredient'
 depends 'hostsfile'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,27 +35,34 @@ file '/etc/supermarket/supermarket.json' do
   notifies :reconfigure, 'chef_server_ingredient[supermarket]'
 end
 
-if node['supermarket_package']['package_source']
-  pkgname = ::File.basename(node['supermarket_package']['package_source'])
+if node['supermarket_omnibus']['package_url']
+  pkgname = ::File.basename(node['supermarket_omnibus']['package_url'])
   cache_path = ::File.join(Chef::Config[:file_cache_path], pkgname).gsub(/~/, '-')
 
   # recipe
   remote_file cache_path do
-    source node['supermarket_package']['package_source']
+    source node['supermarket_omnibus']['package_url']
     mode '0644'
   end
+end
+
+case node['platform_family']
+when 'debian'
+  node.default['apt-chef']['repo_name'] = node['supermarket_omnibus']['package_repo']
+when 'rhel'
+  node.default['yum-chef']['repositoryid'] = node['supermarket_omnibus']['package_repo']
 end
 
 chef_server_ingredient 'supermarket' do
   ctl_command '/opt/supermarket/bin/supermarket-ctl'
 
-  # Prefer package_source if set over custom repository
-  if node['supermarket_package']['package_source']
-    Chef::Log.info "Using Supermarket package source: #{node['supermarket_package']['package_source']}"
+  # Prefer package_url if set over custom repository
+  if node['supermarket_omnibus']['package_url']
+    Chef::Log.info "Using Supermarket package source: #{node['supermarket_omnibus']['package_url']}"
     package_source cache_path
   else
-    Chef::Log.info "Using Supermarket packagecloud repo #{node['supermarket_package']['packagecloud_repo']}"
-    repository node['supermarket_package']['packagecloud_repo']
+    Chef::Log.info "Using CHEF's public repository #{node['supermarket_omnibus']['package_repo']}"
+    version node['supermarket_omnibus']['package_version']
   end
 
   notifies :reconfigure, 'chef_server_ingredient[supermarket]'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,8 +6,8 @@
 
 # Configure Supermarket server hostname in /etc/hosts if it isn't there (AWS)
 hostsfile_entry node['ipaddress'] do
-  hostname node.hostname
-  not_if "grep #{node.hostname} /etc/hosts"
+  hostname node['hostname']
+  not_if "grep #{node['hostname']} /etc/hosts"
 end
 
 directory '/etc/supermarket' do
@@ -32,7 +32,7 @@ file '/etc/supermarket/supermarket.json' do
   group "root"
   mode "0644"
   content JSON.pretty_generate(node['supermarket_omnibus'])
-  notifies :reconfigure, 'chef_server_ingredient[supermarket]'
+  notifies :reconfigure, 'chef_ingredient[supermarket]'
 end
 
 if node['supermarket_omnibus']['package_url']
@@ -53,7 +53,7 @@ when 'rhel'
   node.default['yum-chef']['repositoryid'] = node['supermarket_omnibus']['package_repo']
 end
 
-chef_server_ingredient 'supermarket' do
+chef_ingredient 'supermarket' do
   ctl_command '/opt/supermarket/bin/supermarket-ctl'
 
   # Prefer package_url if set over custom repository
@@ -65,5 +65,5 @@ chef_server_ingredient 'supermarket' do
     version node['supermarket_omnibus']['package_version']
   end
 
-  notifies :reconfigure, 'chef_server_ingredient[supermarket]'
+  notifies :reconfigure, 'chef_ingredient[supermarket]'
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -5,18 +5,19 @@
 # Copyright (c) 2015 Irving Popovetsky, All Rights Reserved.
 
 require 'spec_helper'
+require 'mixlib/versioning' # new chef-ingredient makes heavy use of this library
 
 describe 'supermarket-omnibus-cookbook::default' do
 
   context 'When all attributes are default, it should fail because of nil checks' do
 
     let(:chef_run) do
-      runner = ChefSpec::SoloRunner.new
+      runner = ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5')
       runner.converge(described_recipe)
     end
 
     before do
-      stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
+      stub_command("grep Fauxhai /etc/hosts").and_return('33.33.33.11 Fauxhai')
     end
 
     it 'raises an error' do
@@ -27,7 +28,7 @@ describe 'supermarket-omnibus-cookbook::default' do
 
   context 'When chef_server (oc-id) attributes are correctly specified' do
     let(:chef_run) do
-      runner = ChefSpec::SoloRunner.new do |node|
+      runner = ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5') do |node|
         node.set['supermarket_omnibus']['chef_server_url'] = 'https://chefserver.mycorp.com'
         node.set['supermarket_omnibus']['chef_oauth2_app_id'] = 'blahblah'
         node.set['supermarket_omnibus']['chef_oauth2_secret'] = 'bob_lawblaw'
@@ -36,7 +37,7 @@ describe 'supermarket-omnibus-cookbook::default' do
     end
 
     before do
-      stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
+      stub_command("grep Fauxhai /etc/hosts").and_return('33.33.33.11 Fauxhai')
     end
 
     it 'converges successfully' do
@@ -46,7 +47,7 @@ describe 'supermarket-omnibus-cookbook::default' do
 
   context 'When a repository chef-current is specified' do
     let(:chef_run) do
-      runner = ChefSpec::SoloRunner.new(step_into: 'chef_server_ingredient') do |node|
+      runner = ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5', step_into: 'chef_ingredient') do |node|
         node.set['supermarket_omnibus']['package_repo']  = 'chef-current'
         node.set['supermarket_omnibus']['chef_server_url']    = 'https://chefserver.mycorp.com'
         node.set['supermarket_omnibus']['chef_oauth2_app_id'] = 'blahblah'
@@ -56,16 +57,16 @@ describe 'supermarket-omnibus-cookbook::default' do
     end
 
     before do
-      stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
+      stub_command("grep Fauxhai /etc/hosts").and_return('33.33.33.11 Fauxhai')
     end
 
-    it 'uses the specified chef_server_ingredient[supermarket] with a repository of "chef-current"' do
-      expect(chef_run).to install_chef_server_ingredient('supermarket')
-        .with(repository: 'chef-current')
+    it 'includes the yum-chef::default recipe with the chef-current repositoryid' do
+      expect(chef_run).to include_recipe('yum-chef::default')
+      expect(chef_run.node['yum-chef']['repositoryid']) == 'chef-current'
     end
 
     it 'creates a package_repository named "chef-current"' do
-      expect(chef_run).to create_repository('chef-current')
+      expect(chef_run).to create_yum_repository('chef-current')
     end
 
     it 'converges successfully' do
@@ -76,7 +77,7 @@ describe 'supermarket-omnibus-cookbook::default' do
 
   context 'When a package_url is specified, packagecloud should not be used' do
     let(:chef_run) do
-      runner = ChefSpec::SoloRunner.new do |node|
+      runner = ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5') do |node|
         node.set['supermarket_omnibus']['package_url']  = 'https://web-dl.packagecloud.io/chef/stable/packages/el/6/supermarket-1.10.1~alpha.0-1.el5.x86_64.rpm'
         node.set['supermarket_omnibus']['chef_server_url']    = 'https://chefserver.mycorp.com'
         node.set['supermarket_omnibus']['chef_oauth2_app_id'] = 'blahblah'
@@ -86,16 +87,20 @@ describe 'supermarket-omnibus-cookbook::default' do
     end
 
     before do
-      stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
+      stub_command("grep Fauxhai /etc/hosts").and_return('33.33.33.11 Fauxhai')
     end
 
-    it 'uses the specified chef_server_ingredient[supermarket] with a package_url set' do
-      expect(chef_run).to install_chef_server_ingredient('supermarket')
+    it 'fetches the supermarket package and places it on the filesystem' do
+      expect(chef_run).to create_remote_file("#{Chef::Config[:file_cache_path]}/supermarket-1.10.1-alpha.0-1.el5.x86_64.rpm")
+    end
+
+    it 'uses the specified chef_ingredient[supermarket] with a package_url set' do
+      expect(chef_run).to install_chef_ingredient('supermarket')
         .with(package_source: ::File.join(Chef::Config[:file_cache_path], 'supermarket-1.10.1-alpha.0-1.el5.x86_64.rpm'))
     end
 
     it 'does not create a package_repository named "chef-stable"' do
-      expect(chef_run).to_not create_repository('chef-stable')
+      expect(chef_run).to_not create_yum_repository('chef-stable')
     end
 
     it 'converges successfully' do
@@ -105,7 +110,7 @@ describe 'supermarket-omnibus-cookbook::default' do
 
   context 'When a package_url is specified, the Rpm provider should be used on RHEL systems' do
     let(:chef_run) do
-      runner = ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5', step_into: 'chef_server_ingredient') do |node|
+      runner = ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5', step_into: 'chef_ingredient') do |node|
         node.set['supermarket_omnibus']['package_url']  = 'https://web-dl.packagecloud.io/chef/stable/packages/el/6/supermarket-1.10.1~alpha.0-1.el5.x86_64.rpm'
         node.set['supermarket_omnibus']['chef_server_url']    = 'https://chefserver.mycorp.com'
         node.set['supermarket_omnibus']['chef_oauth2_app_id'] = 'blahblah'
@@ -115,12 +120,11 @@ describe 'supermarket-omnibus-cookbook::default' do
     end
 
     before do
-      stub_command("grep Fauxhai /etc/hosts").and_return('33.33.33.11 chefspec')
+      stub_command("grep Fauxhai /etc/hosts").and_return('33.33.33.11 Fauxhai')
     end
 
-    it 'installs an Rpm package' do
-      expect(chef_run).to install_rpm_package('supermarket')
-      expect(chef_run).to_not install_yum_package('supermarket')
+    it 'fetches the supermarket package and places it on the filesystem' do
+      expect(chef_run).to create_remote_file("#{Chef::Config[:file_cache_path]}/supermarket-1.10.1-alpha.0-1.el5.x86_64.rpm")
     end
 
     it 'converges successfully' do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -44,10 +44,10 @@ describe 'supermarket-omnibus-cookbook::default' do
     end
   end
 
-  context 'When a chef_server_ingredient repository chef/current is specified' do
+  context 'When a repository chef-current is specified' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(step_into: 'chef_server_ingredient') do |node|
-        node.set['supermarket_package']['packagecloud_repo']  = 'chef/current'
+        node.set['supermarket_omnibus']['package_repo']  = 'chef-current'
         node.set['supermarket_omnibus']['chef_server_url']    = 'https://chefserver.mycorp.com'
         node.set['supermarket_omnibus']['chef_oauth2_app_id'] = 'blahblah'
         node.set['supermarket_omnibus']['chef_oauth2_secret'] = 'bob_loblaw'
@@ -59,13 +59,13 @@ describe 'supermarket-omnibus-cookbook::default' do
       stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
     end
 
-    it 'uses the specified chef_server_ingredient[supermarket] with a repository of "chef/current"' do
+    it 'uses the specified chef_server_ingredient[supermarket] with a repository of "chef-current"' do
       expect(chef_run).to install_chef_server_ingredient('supermarket')
-        .with(repository: 'chef/current')
+        .with(repository: 'chef-current')
     end
 
-    it 'creates a packagecloud_repository named "chef/current"' do
-      expect(chef_run).to create_packagecloud_repo('chef/current')
+    it 'creates a package_repository named "chef-current"' do
+      expect(chef_run).to create_repository('chef-current')
     end
 
     it 'converges successfully' do
@@ -74,10 +74,10 @@ describe 'supermarket-omnibus-cookbook::default' do
   end
 
 
-  context 'When a package_source is specified, packagecloud should not be used' do
+  context 'When a package_url is specified, packagecloud should not be used' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new do |node|
-        node.set['supermarket_package']['package_source']  = 'https://web-dl.packagecloud.io/chef/stable/packages/el/6/supermarket-1.10.1~alpha.0-1.el5.x86_64.rpm'
+        node.set['supermarket_omnibus']['package_url']  = 'https://web-dl.packagecloud.io/chef/stable/packages/el/6/supermarket-1.10.1~alpha.0-1.el5.x86_64.rpm'
         node.set['supermarket_omnibus']['chef_server_url']    = 'https://chefserver.mycorp.com'
         node.set['supermarket_omnibus']['chef_oauth2_app_id'] = 'blahblah'
         node.set['supermarket_omnibus']['chef_oauth2_secret'] = 'bob_loblaw'
@@ -89,13 +89,13 @@ describe 'supermarket-omnibus-cookbook::default' do
       stub_command("grep chefspec /etc/hosts").and_return('33.33.33.11 chefspec')
     end
 
-    it 'uses the specified chef_server_ingredient[supermarket] with a package_source set' do
+    it 'uses the specified chef_server_ingredient[supermarket] with a package_url set' do
       expect(chef_run).to install_chef_server_ingredient('supermarket')
         .with(package_source: ::File.join(Chef::Config[:file_cache_path], 'supermarket-1.10.1-alpha.0-1.el5.x86_64.rpm'))
     end
 
-    it 'does not create a packagecloud_repository named "chef/stable"' do
-      expect(chef_run).to_not create_packagecloud_repo('chef/stable')
+    it 'does not create a package_repository named "chef-stable"' do
+      expect(chef_run).to_not create_repository('chef-stable')
     end
 
     it 'converges successfully' do
@@ -103,10 +103,10 @@ describe 'supermarket-omnibus-cookbook::default' do
     end
   end
 
-  context 'When a package_source is specified, the Rpm provider should be used on RHEL systems' do
+  context 'When a package_url is specified, the Rpm provider should be used on RHEL systems' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.5', step_into: 'chef_server_ingredient') do |node|
-        node.set['supermarket_package']['package_source']  = 'https://web-dl.packagecloud.io/chef/stable/packages/el/6/supermarket-1.10.1~alpha.0-1.el5.x86_64.rpm'
+        node.set['supermarket_omnibus']['package_url']  = 'https://web-dl.packagecloud.io/chef/stable/packages/el/6/supermarket-1.10.1~alpha.0-1.el5.x86_64.rpm'
         node.set['supermarket_omnibus']['chef_server_url']    = 'https://chefserver.mycorp.com'
         node.set['supermarket_omnibus']['chef_oauth2_app_id'] = 'blahblah'
         node.set['supermarket_omnibus']['chef_oauth2_secret'] = 'bob_loblaw'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -5,7 +5,6 @@
 # Copyright (c) 2015 Irving Popovetsky, All Rights Reserved.
 
 require 'spec_helper'
-require 'mixlib/versioning' # new chef-ingredient makes heavy use of this library
 
 describe 'supermarket-omnibus-cookbook::default' do
 

--- a/test/integration/default/serverspec/ruby_spec.rb
+++ b/test/integration/default/serverspec/ruby_spec.rb
@@ -1,8 +1,0 @@
-require_relative 'spec_helper'
-
-describe 'ruby' do
-  it '2.1.3 installed and used by default' do
-    cmd = command '/opt/supermarket/embedded/bin/ruby -v'
-    expect(cmd.stdout).to match 'ruby 2.1.3'
-  end
-end


### PR DESCRIPTION
Finishing the work of @binamov,  this completes the work to convert to chef-ingredient with working tests.

New attributes:
`default['supermarket_omnibus']['package_version']` can be a Semver like `1.10.0` or the default `:latest`

Note some breaking changes, these will require a major version bump:
* `default['supermarket_package']['packagecloud_repo']` -> `default['supermarket_omnibus']['package_repo']`
* the repos have changed their name from `chef/stable` to `chef-stable` or `chef-current`

The new way to override the `yum-chef` or `apt-chef` repo location is by overriding the attributes specified in those cookbooks.

Fixes: #11 #15 #16

CC:  @jtimberman @nellshamrell @lauck for review
