### PR TITLE
Travis build improvements

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -24,6 +24,7 @@ platforms:
     provision_command:
       - /usr/bin/apt-get update
       - /usr/bin/apt-get install apt-transport-https net-tools -y
+      - mkdir /etc/cron.hourly
 - name: ubuntu-14.04
   driver:
     image: ubuntu-upstart:14.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 # Use Travis's cointainer based infrastructure
-rvm: 2.2
-
 sudo: required
 services: docker
+
+addons:
+ apt:
+   sources:
+     - chef-stable-precise
+   packages:
+     - chefdk
 
 env:
   matrix:
@@ -13,8 +18,6 @@ env:
 # Don't `bundle install`
 install: echo "skip bundle install"
 
-# Ensure we make ChefDK's Ruby the default
-before_install: curl -L https://www.getchef.com/chef/install.sh | sudo bash -s -- -P chefdk
 before_script:
   # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142230889
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/chef-cookbooks/supermarket-omnibus-cookbook.svg?branch=master)](https://travis-ci.org/chef-cookbooks/supermarket-omnibus-cookbook)
+
 # supermarket-omnibus-cookbook
 
 This cookbook installs the [Chef Supermarket](https://github.com/opscode/supermarket) server using the [omnibus-supermarket](https://github.com/opscode/omnibus-supermarket) packages from PackageCloud.  


### PR DESCRIPTION
* Fix issue with `/etc/cron.hourly` missing on Ubuntu precise 
* add build status to readme
* speed up Travis runs by using the Chef apt repo (instead of install.sh) and removing rvm