### PR TITLE
adds notifies :reconfigure to supermarket chef_ingredient

### DIFF
--- a/libraries/supermarket_server.rb
+++ b/libraries/supermarket_server.rb
@@ -109,6 +109,7 @@ class Chef
             Chef::Log.info "Using CHEF's public repository #{node['supermarket_omnibus']['package_repo']}"
             version node['supermarket_omnibus']['package_version']
           end
+          notifies :reconfigure, 'chef_ingredient[supermarket]'
         end
       end
     end

--- a/recipes/upgrade.rb
+++ b/recipes/upgrade.rb
@@ -1,0 +1,43 @@
+node.set['supermarket_omnibus']['upgrade_enabled'] = true
+node.set['supermarket_omnibus']['restart_after_upgrades'] = true
+
+unless node['supermarket_omnibus']['upgrade_enabled']
+  Chef::Log.fatal('The supermarket-omnibus-cookbook::upgrade recipe was added to the node,')
+  Chef::Log.fatal('however the attribute `node["supermarket_omnibus"]["upgrade_enabled"]` was not set.')
+  Chef::Log.fatal('Bailing out here so this node does not upgrade.')
+  raise
+end
+
+  require 'set'
+
+  file "/root/chef_resources-#{node.name}.json" do
+    resource_clxn = Chef::ResourceCollection.new
+    run_context.resource_collection.each do |r|
+      next if r.class.to_s == 'Chef::Resource::NodeMetadata'
+      r = r.dup
+      r.instance_eval do
+        content('')   if respond_to?(:content)
+        variables({}) if respond_to?(:variables)
+        remove_instance_variable('@options') rescue nil
+        params.delete(:options) if respond_to?(:params)
+        # if respond_to?(:options)
+        #   begin ; options({})  ; rescue options('') ; end
+        # end
+        @delayed_notifications = []
+        @immediate_notifications = []
+      end
+      resource_clxn << r
+    end
+    content       resource_clxn.to_json(JSON::PRETTY_STATE_PROTOTYPE)+"\n"
+    action        :create
+    owner         'root'
+    group         'root'
+    mode          "0600" # only readable by root
+  end
+
+#walk_resource_path
+
+#resources(apt_package: 'supermarket').notifies :reconfigure, 'supermarket_server[supermarket]'
+#resources(supermarket_server: 'supermarket').notifies :reconfigure, 'supermarket_server[supermarket]'
+#resources(Chef::Resource::SupermarketServer::chef_ingredient: 'supermarket').notifies :reconfigure, 'supermarket_server[supermarket]'
+#resources(supermarket_server: 'supermarket').action :upgrade


### PR DESCRIPTION
This is an attempt to address the observation that when `node['supermarket_omnibus']['package_version']` changes, a `reconfigure` is NOT run, leaving the supermarket instance in a faulted state.  This change has been tested as such:

- `package_version` does not change -> converge does not change anything
- `package_version` changes, -> converge installs new package version and then runs `reconfigure`