### PR TITLE
Upgrade the omnibus install when version changes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+  - master
 # Use Travis's cointainer based infrastructure
 sudo: required
 services: docker
@@ -15,7 +18,7 @@ env:
   - INSTANCE=default-ubuntu-1204
   - INSTANCE=default-centos-71
 
-# Do `bundle install` to get mixlib-shellout ~> 1.0. 
+# Do `bundle install` to get mixlib-shellout ~> 1.0.
 # test-kitchen 1.6.0 and test-kitchen 1.6.0 depend on mixlib-install ~> 0.7.0.
 install:
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"

--- a/libraries/supermarket_server.rb
+++ b/libraries/supermarket_server.rb
@@ -95,7 +95,7 @@ class Chef
             Chef::Log.info "Using CHEF's public channel #{node['supermarket_omnibus']['package_repo']}"
             version node['supermarket_omnibus']['package_version']
           end
-          action [:install, :reconfigure]
+          action [:upgrade, :reconfigure]
         end
       end
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'all_rights'
 description      'Installs and Configures Supermarket from the Omnibus packages on packages.chef.io'
 source_url       'https://github.com/irvingpop/supermarket-omnibus-cookbook'
 issues_url       'https://github.com/irvingpop/supermarket-omnibus-cookbook/issues'
-version          '1.4.0'
+version          '1.4.1'
 
 
 depends 'chef-ingredient', '>= 0.18.0'

--- a/spec/unit/libraries/supermarket_server_spec.rb
+++ b/spec/unit/libraries/supermarket_server_spec.rb
@@ -42,7 +42,7 @@ describe 'supermarket-omnibus-cookbook::default' do
     end
 
     it 'creates the template with the correct values' do
-      expect(chef_run).to install_chef_ingredient('supermarket').with(
+      expect(chef_run).to upgrade_chef_ingredient('supermarket').with(
         config: JSON.pretty_generate(chef_server_url: 'https://chefserver.mycorp.com',
                                      chef_oauth2_app_id: 'blahblah',
                                      chef_oauth2_secret: 'bob_lawblaw',
@@ -75,7 +75,7 @@ describe 'supermarket-omnibus-cookbook::default' do
     end
 
     it 'creates the template with the correct values' do
-      expect(chef_run).to install_chef_ingredient('supermarket').with(
+      expect(chef_run).to upgrade_chef_ingredient('supermarket').with(
         config: JSON.pretty_generate(chef_oauth2_mode: 'blah',
                                      chef_server_url: 'https://chefserver.mycorp.com',
                                      chef_oauth2_app_id: 'blahblah',
@@ -108,7 +108,7 @@ describe 'supermarket-omnibus-cookbook::default' do
     end
 
     it 'tells chef-ingredient to install the supermarket package from the current channel' do
-      expect(chef_run).to install_chef_ingredient('supermarket').with(channel: :current)
+      expect(chef_run).to upgrade_chef_ingredient('supermarket').with(channel: :current)
     end
 
     it 'fetches the supermarket package places it on the filesystem' do
@@ -140,7 +140,7 @@ describe 'supermarket-omnibus-cookbook::default' do
     end
 
     it 'uses the specified chef_ingredient[supermarket] with a package_source set' do
-      expect(chef_run).to install_chef_ingredient('supermarket')
+      expect(chef_run).to upgrade_chef_ingredient('supermarket')
         .with(package_source: ::File.join(Chef::Config[:file_cache_path], 'supermarket-1.10.1-alpha.0-1.el5.x86_64.rpm'))
     end
 


### PR DESCRIPTION
The chef_ingredient install action was _not_ installing a newer version
of the omnibus package if a newer version was declared.