### PR TITLE
collaborators feature on by default

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -45,7 +45,7 @@ platforms:
     platform: rhel
     pid_one_command: /sbin/init
     intermediate_instructions:
-      - RUN yum -y install which initscripts
+      - RUN yum -y install which initscripts crontabs
 
 - name: centos-7
   driver:
@@ -53,7 +53,7 @@ platforms:
     platform: rhel
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN yum -y install lsof which systemd-sysv initscripts
+      - RUN yum -y install lsof which systemd-sysv initscripts crontabs
 
 - name: fedora-latest
   driver:

--- a/README.md
+++ b/README.md
@@ -64,11 +64,7 @@ supermarket['ssl']['certificate'] = '/full/path/to/ssl.crt'
 supermarket['ssl']['certificate_key'] = '/full/path/to/ssl.key'
 ```
 
-To enable a recent [collaborator groups](https://www.chef.io/blog/2015/12/18/collaborator-groups-on-supermarket/) [feature](https://www.youtube.com/watch?v=1t1T5CQ0j48) you'll need to add the following attribute into your cookbook wrapper:
-
-```ruby
-default['supermarket_omnibus']['config']['features'] = 'tools, gravatar, collaborator_groups'
-```
+The [Collaborator Groups](https://www.chef.io/blog/2015/12/18/collaborator-groups-on-supermarket/) [feature](https://www.youtube.com/watch?v=1t1T5CQ0j48) is enabled in this cookbook's `attributes/default.rb`.
 
 :warning: It's super important to be aware that **supermarket.json always wins**. Best practice is to modify your supermarket configuration via `['config']` setting in a wrapper cookbook.
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ namespace :style do
     FoodCritic::Rake::LintTask.new(:chef) do |t|
       t.options = {
         fail_tags: ['any'],
-        progress: true
+        progress: true,
       }
     end
   rescue LoadError

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,5 +12,8 @@ default['supermarket_omnibus']['package_repo'] = 'stable'
 # Specify a recipe to install supermarket from a custom repo.
 default['supermarket_omnibus']['custom_repo_recipe'] = nil
 
+# Enable collaborator groups
+default['supermarket_omnibus']['config']['features'] = 'tools, gravatar, collaborator_groups'
+
 # use the following to consume integration builds:
 # default['supermarket_omnibus']['package_repo'] = 'current'

--- a/resources/supermarket_server.rb
+++ b/resources/supermarket_server.rb
@@ -69,7 +69,7 @@ action_class do
       'chef_server_url' => new_resource.chef_server_url,
       'chef_oauth2_app_id' => new_resource.chef_oauth2_app_id,
       'chef_oauth2_secret' => new_resource.chef_oauth2_secret,
-      'chef_oauth2_verify_ssl' => new_resource.chef_oauth2_verify_ssl
+      'chef_oauth2_verify_ssl' => new_resource.chef_oauth2_verify_ssl,
     }
   end
 

--- a/spec/unit/libraries/supermarket_server_spec.rb
+++ b/spec/unit/libraries/supermarket_server_spec.rb
@@ -78,7 +78,8 @@ describe 'supermarket-omnibus-cookbook::default' do
 
     it 'creates the template with the correct values' do
       expect(chef_run).to upgrade_chef_ingredient('supermarket').with(
-        config: JSON.pretty_generate(features: 'tools, gravatar, collaborator_groups',chef_oauth2_mode: 'blah',
+        config: JSON.pretty_generate(features: 'tools, gravatar, collaborator_groups',
+                                     chef_oauth2_mode: 'blah',
                                      chef_server_url: 'https://chefserver.mycorp.com',
                                      chef_oauth2_app_id: 'blahblah',
                                      chef_oauth2_secret: 'bob_lawblaw',

--- a/spec/unit/libraries/supermarket_server_spec.rb
+++ b/spec/unit/libraries/supermarket_server_spec.rb
@@ -29,6 +29,7 @@ describe 'supermarket-omnibus-cookbook::default' do
         node.normal['supermarket_omnibus']['chef_server_url'] = 'https://chefserver.mycorp.com'
         node.normal['supermarket_omnibus']['chef_oauth2_app_id'] = 'blahblah'
         node.normal['supermarket_omnibus']['chef_oauth2_secret'] = 'bob_lawblaw'
+        node.normal['supermarket_omnibus']['config']['features'] = 'tools, gravatar, collaborator_groups'
       end
       runner.converge(described_recipe)
     end
@@ -43,7 +44,8 @@ describe 'supermarket-omnibus-cookbook::default' do
 
     it 'creates the template with the correct values' do
       expect(chef_run).to upgrade_chef_ingredient('supermarket').with(
-        config: JSON.pretty_generate(chef_server_url: 'https://chefserver.mycorp.com',
+        config: JSON.pretty_generate(features: 'tools, gravatar, collaborator_groups',
+                                     chef_server_url: 'https://chefserver.mycorp.com',
                                      chef_oauth2_app_id: 'blahblah',
                                      chef_oauth2_secret: 'bob_lawblaw',
                                      chef_oauth2_verify_ssl: false),
@@ -76,7 +78,7 @@ describe 'supermarket-omnibus-cookbook::default' do
 
     it 'creates the template with the correct values' do
       expect(chef_run).to upgrade_chef_ingredient('supermarket').with(
-        config: JSON.pretty_generate(chef_oauth2_mode: 'blah',
+        config: JSON.pretty_generate(features: 'tools, gravatar, collaborator_groups',chef_oauth2_mode: 'blah',
                                      chef_server_url: 'https://chefserver.mycorp.com',
                                      chef_oauth2_app_id: 'blahblah',
                                      chef_oauth2_secret: 'bob_lawblaw',


### PR DESCRIPTION
### Description

The purpose of this change is to make the Collaborator Groups feature enabled by default.
I cannot think of any downsides to making it the default.

### Issues Resolved

N/A

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Jeremy J. Miller <jm@chef.io>