### PR TITLE
require a chef-ingredient that uses up-to-date mixlib-install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the supermarket-omnibus-cookbook cookbook.
 
+## 2.0.1 (2017-01-20)
+
+- Upgrade chef-ingredient to use updated mixlib-install (PackageRouter support)
+
 ## 2.0.0 (2016-09-12)
 
 - Convert the LWRP to a custom resource and use compat_resource for Chef 12.1+ compatibility

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs and Configures Supermarket from the Omnibus packages 
 source_url       'https://github.com/irvingpop/supermarket-omnibus-cookbook'
 issues_url       'https://github.com/irvingpop/supermarket-omnibus-cookbook/issues'
 chef_version     '>= 12.1'
-version          '2.0.0'
+version          '2.0.1'
 
 supports 'ubuntu'
 supports 'redhat'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ supports 'ubuntu'
 supports 'redhat'
 supports 'centos'
 
-depends 'chef-ingredient', '>= 0.19.0'
+depends 'chef-ingredient', '>= 0.21.2'
 depends 'compat_resource', '>= 12.14.3'
 depends 'hostsfile'
 depends 'fancy_execute'


### PR DESCRIPTION
### Description

Use a chef-ingredient that uses a mixlib-install that retrieves packages from package router site.

### Issues Resolved

Fixes installs trying to download packages from bintray.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
