### PR TITLE
Remove class_eval usage and require Chef 12.7+

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,11 +15,11 @@ platforms:
     driver:
       network:
       - ["private_network", {ip: "33.33.33.22"}]
-  - name: centos-6.9
+  - name: centos-6
     driver:
       network:
       - ["private_network", {ip: "33.33.33.25"}]
-  - name: centos-7.3
+  - name: centos-7
     driver:
       network:
       - ["private_network", {ip: "33.33.33.28"}]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,7 +15,7 @@ platforms:
     driver:
       network:
       - ["private_network", {ip: "33.33.33.22"}]
-  - name: centos-6.8
+  - name: centos-6.9
     driver:
       network:
       - ["private_network", {ip: "33.33.33.25"}]

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 addons:
   apt:
     sources:
-      - chef-stable-trusty
+      - chef-current-trusty
     packages:
       - chefdk
 
@@ -26,15 +26,15 @@ env:
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-  - eval "$(/opt/chefdk/bin/chef shell-init bash)"
-  - /opt/chefdk/embedded/bin/chef --version
-  - /opt/chefdk/embedded/bin/cookstyle --version
-  - /opt/chefdk/embedded/bin/foodcritic --version
+  - eval "$(chef shell-init bash)"
+  - chef --version
+  - cookstyle --version
+  - foodcritic --version
 
-script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}
+script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen verify ${INSTANCE}
 
 matrix:
   include:
     - script:
-      - /opt/chefdk/bin/chef exec delivery local all
+      - chef exec delivery local all
       env: UNIT_AND_LINT=1

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This cookbook also renders supermarket.json file which is used for managing conf
 
 ### Chef
 
-- Chef 12.5+
+- Chef 12.7+
 
 ### Cookbooks
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Apache-2.0'
 description      'Installs and Configures Supermarket from the Omnibus packages on packages.chef.io'
 source_url       'https://github.com/chef-cookbooks/supermarket-omnibus-cookbook'
 issues_url       'https://github.com/chef-cookbooks/supermarket-omnibus-cookbook/issues'
-chef_version     '>= 12.5' if respond_to?(:chef_version)
+chef_version     '>= 12.7' if respond_to?(:chef_version)
 version          '3.0.0'
 
 supports 'ubuntu'

--- a/resources/supermarket_server.rb
+++ b/resources/supermarket_server.rb
@@ -63,7 +63,7 @@ action :create do
   end
 end
 
-action_class.class_eval do
+action_class do
   def supermarket_config
     {
       'chef_server_url' => new_resource.chef_server_url,


### PR DESCRIPTION
This resolves issues with later Chef 12 releases

Signed-off-by: Tim Smith <tsmith@chef.io>