### PR TITLE
add project state and response time expectations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-* @chef-cookbooks/cookbook_engineering_team
+# Order is important. The last matching pattern has the most precedence.
+
+*                                @chef/supermarket-reviewers

--- a/README.md
+++ b/README.md
@@ -5,11 +5,17 @@
 This cookbook installs the [Chef Supermarket](https://github.com/opscode/supermarket) server using the [omnibus-supermarket](https://github.com/opscode/omnibus-supermarket) packages from package.chef.io.<br>
 This cookbook also renders supermarket.json file which is used for managing configuration of Supermarket.
 
+**Umbrella Project**: [Supermarket](https://github.com/chef/chef-oss-practices/blob/master/projects/supermarket.md)
+
+* **[Project State](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** Maintained
+* **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
+* **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
+
 ## Requirements
 
 ### Platforms
 
-- Ubuntu 12.04+
+- Ubuntu 14.04+
 - RHEL 6+
 
 ### Chef


### PR DESCRIPTION
In accordance with [the OSS practices repo states definition](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md).

Also update supported platforms.